### PR TITLE
Fix where notification didn't received a proper routine id

### DIFF
--- a/app/src/main/java/org/coeg/routine/activities/AddRoutineActivity.java
+++ b/app/src/main/java/org/coeg/routine/activities/AddRoutineActivity.java
@@ -25,6 +25,7 @@ import com.shawnlin.numberpicker.NumberPicker;
 
 import org.coeg.routine.R;
 import org.coeg.routine.backend.Days;
+import org.coeg.routine.backend.History;
 import org.coeg.routine.backend.PreferencesStorage;
 import org.coeg.routine.backend.Routine;
 import org.coeg.routine.backend.RoutinesHandler;
@@ -581,6 +582,17 @@ public class AddRoutineActivity extends AppCompatActivity
         @Override
         protected Void doInBackground(Routine... routine)
         {
+            LinkedList<History> historyList = new LinkedList<>(handler.getAllHistory());
+
+            // Also delete history
+            for (History history : historyList)
+            {
+                if (history.getRoutineId() == routine[0].getId())
+                {
+                    handler.deleteHistory(history);
+                }
+            }
+
             handler.deleteRoutine(routine[0]);
             return null;
         }

--- a/app/src/main/java/org/coeg/routine/backend/AlarmService.java
+++ b/app/src/main/java/org/coeg/routine/backend/AlarmService.java
@@ -80,17 +80,18 @@ public class AlarmService extends Service
         long[] vibratePattern = new long[] { 500, 500, 500 };
 
         Intent receiver = new Intent(this, NotificationActionReceiver.class);
+
         PendingIntent pOkIntent = PendingIntent.getBroadcast(
                 this, ACTION_OK, receiver
                         .putExtra("Request Code", ACTION_OK)
                         .putExtra("Routine ID", routineID)
-                        .putExtra("Routine Name", routineName), 0);
+                        .putExtra("Routine Name", routineName), PendingIntent.FLAG_UPDATE_CURRENT);
 
         PendingIntent pSnoozeIntent = PendingIntent.getBroadcast(
                 this, ACTION_SNOOZE, receiver
                         .putExtra("Request Code", ACTION_SNOOZE)
                         .putExtra("Routine ID", routineID)
-                        .putExtra("Routine Name", routineName), 0);
+                        .putExtra("Routine Name", routineName), PendingIntent.FLAG_UPDATE_CURRENT);
 
         PendingIntent pendingIntent = PendingIntent.getActivity(this, routineID, new Intent(), 0);
 

--- a/app/src/main/java/org/coeg/routine/backend/NotificationActionReceiver.java
+++ b/app/src/main/java/org/coeg/routine/backend/NotificationActionReceiver.java
@@ -37,6 +37,8 @@ public class NotificationActionReceiver extends BroadcastReceiver
         int routineID = intent.getIntExtra("Routine ID", -1);
         String routineName = intent.getStringExtra("Routine Name");
 
+        Log.i("Notification Routine ID", "" + routineID);
+
         // Stop current service
         Intent intentServiceToStop = new Intent(context, AlarmService.class);
 


### PR DESCRIPTION
Deleting routine will now delete the history representing that routine id
to prevent errors (temporary fix)

Co-authored-by: reaperastrea <55103903+reaperastrea@users.noreply.github.com>